### PR TITLE
Loading From Reader

### DIFF
--- a/src/wordclusters.rs
+++ b/src/wordclusters.rs
@@ -13,7 +13,12 @@ pub struct WordClusters {
 impl WordClusters {
     pub fn load_from_file(file_name: &str) -> Result<WordClusters, Word2VecError> {
         let file = try!(File::open(file_name));
-        let mut reader = BufReader::new(file);
+        let reader = BufReader::new(file);
+
+        return WordClusters::load_from_reader(reader)
+    }
+
+    pub fn load_from_reader<R: BufRead>(mut reader: R) -> Result<WordClusters, Word2VecError> {
         let mut buffer = String::new();
         let mut clusters: HashMap<i32, Vec<String>> = HashMap::new();
         while try!(reader.read_line(&mut buffer)) > 0 {

--- a/src/wordvectors.rs
+++ b/src/wordvectors.rs
@@ -17,13 +17,23 @@ pub struct WordVector {
 }
 
 impl WordVector {
+
     /// Load a word vector space from file
     ///
     /// Word2vec is able to store the word vectors in a binary file. This function parses the file
     /// and loads the vectors into RAM.
     pub fn load_from_binary(file_name: &str) -> Result<WordVector, Word2VecError> {
         let file = try!(File::open(file_name));
-        let mut reader = BufReader::new(file);
+        let reader = BufReader::new(file);
+
+        return WordVector::load_from_reader(reader);
+    }
+
+    /// Load a word vector space from a reader
+    ///
+    /// Word2vec is able to store the word vectors in a binary format. This function parses the bytes in that format
+    /// and loads the vectors into RAM.
+    pub fn load_from_reader<R: BufRead>(mut reader: R) -> Result<WordVector, Word2VecError> {
         let mut header = String::new();
         try!(reader.read_line(&mut header));
         let header_info = header.split_whitespace()


### PR DESCRIPTION
Added `load_from_reader` methods to `WordClusters` and `WordVectors`. This allows loading word vectors from other sources besides plain files such as a TCP connection or a compressed file.